### PR TITLE
Rudimentary retry support through xautoclaim

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: GoogleCloudPlatform/release-please-action@v2
+        id: release
+        with:
+          release-type: ruby
+          package-name: nagare-redis
+          bump-minor-pre-major: true
+          version-file: "lib/nagare/version.rb"
+      # Checkout code if release was created
+      - uses: actions/checkout@v2
+        if: ${{ steps.release.outputs.release_created }}
+      # Setup ruby if a release was created
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6.5
+        if: ${{ steps.release.outputs.release_created }}
+      # Bundle install
+      - run: bundle install
+        if: ${{ steps.release.outputs.release_created }}
+      # Publish
+      - name: publish gem
+        run: |
+          mkdir -p $HOME/.gem
+          touch $HOME/.gem/credentials
+          chmod 0600 $HOME/.gem/credentials
+          printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+          gem build *.gemspec
+          gem push *.gem
+        env:
+          # Make sure to update the secret name
+          # if yours isn't named RUBYGEMS_AUTH_TOKEN
+          GEM_HOST_API_KEY: "${{secrets.RUBYGEMS_AUTH_TOKEN}}"
+        if: ${{ steps.release.outputs.release_created }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,9 +15,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up Ruby 2.6
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6.6
+          ruby-version: 2.6.8
 
       - uses: actions/cache@v1
         with:

--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rake', '~> 12.0'
-gem 'rspec', '~> 3.0'
 gem 'redis', github: 'vavato-be/redis-rb'
+gem 'rspec', '~> 3.0'

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ gemspec
 
 gem 'rake', '~> 12.0'
 gem 'rspec', '~> 3.0'
+gem 'redis', github: 'vavato-be/redis-rb'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,21 +7,21 @@ GIT
 PATH
   remote: .
   specs:
-    nagare-redis (0.1.4)
+    nagare-redis (0.1.5)
       redis (~> 6.2, >= 6.2.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    ast (2.4.1)
+    ast (2.4.2)
     diff-lcs (1.3)
-    parallel (1.19.2)
-    parser (2.7.1.4)
+    parallel (1.20.1)
+    parser (3.0.2.0)
       ast (~> 2.4.1)
     rainbow (3.0.0)
     rake (12.3.2)
-    regexp_parser (1.7.1)
-    rexml (3.2.4)
+    regexp_parser (2.1.1)
+    rexml (3.2.5)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -35,21 +35,22 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.3)
-    rubocop (0.88.0)
+    rubocop (1.18.3)
       parallel (~> 1.10)
-      parser (>= 2.7.1.1)
+      parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.7)
+      regexp_parser (>= 1.8, < 3.0)
       rexml
-      rubocop-ast (>= 0.1.0, < 1.0)
+      rubocop-ast (>= 1.7.0, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (0.2.0)
-      parser (>= 2.7.0.1)
-    rubocop-rspec (1.42.0)
-      rubocop (>= 0.87.0)
-    ruby-progressbar (1.10.1)
-    unicode-display_width (1.7.0)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.7.0)
+      parser (>= 3.0.1.1)
+    rubocop-rspec (2.4.0)
+      rubocop (~> 1.0)
+      rubocop-ast (>= 1.1.0)
+    ruby-progressbar (1.11.0)
+    unicode-display_width (2.0.0)
 
 PLATFORMS
   ruby
@@ -59,8 +60,8 @@ DEPENDENCIES
   rake (~> 12.0)
   redis!
   rspec (~> 3.0)
-  rubocop (~> 0.88, >= 0.88)
-  rubocop-rspec (~> 1.42, >= 1.42.0)
+  rubocop (~> 1.18.3, >= 1.18.3)
+  rubocop-rspec (~> 2.4.0, >= 2.4.0)
 
 BUNDLED WITH
    2.1.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,14 @@
+GIT
+  remote: https://github.com/vavato-be/redis-rb.git
+  revision: 79f36a58e69beb72f3bcef2ae584b30324fa2f07
+  specs:
+    redis (6.2.0)
+
 PATH
   remote: .
   specs:
-    nagare-redis (0.1.3)
-      redis (~> 4.1, >= 4.1.0)
+    nagare-redis (0.1.4)
+      redis (~> 6.2, >= 6.2.0)
 
 GEM
   remote: https://rubygems.org/
@@ -14,7 +20,6 @@ GEM
       ast (~> 2.4.1)
     rainbow (3.0.0)
     rake (12.3.2)
-    redis (4.2.1)
     regexp_parser (1.7.1)
     rexml (3.2.4)
     rspec (3.9.0)
@@ -52,6 +57,7 @@ PLATFORMS
 DEPENDENCIES
   nagare-redis!
   rake (~> 12.0)
+  redis!
   rspec (~> 3.0)
   rubocop (~> 0.88, >= 0.88)
   rubocop-rspec (~> 1.42, >= 1.42.0)

--- a/README.md
+++ b/README.md
@@ -40,19 +40,24 @@ To use with rails, add nagare to the initializers:
 #### config/initializers/nagare.rb
 ```ruby
 Nagare.configure do |config|
-  # After x seconds a consumer is considered dead and its messages
-  # are assigned to a different consumer in the group. Configuring
+  # After x milisseconds a pending message is considered failed and
+  # gets retried by a different consumer in the group. Configuring
   # it too low might cause double processing of messages as a consumer
   # "steals" the load of another while the first one is still processing
   # it and hasn't had the chance to ACK, configuring it too high will 
   # introduce latency in your processing.
-  # Default: 300 (5 minutes)
-  config.dead_consumer_timeout = 600
+  # Default: 600.000 (10 minutes)
+  config.min_idle_time = 600_0000
 
   # This is the consumer group name that will be used or created in
   # Redis. Use a different group for every microservice / application
   # Default: Rails.env
   config.group_name = :monolith
+
+  # A suffix is supported in order to separate different environments
+  # within the same redis database. Useful for development/test. This
+  # gets added automatically to stream names and consumer group names.
+  config.suffix = ''
 
   # URL to connect to redis. Defaults to redis://localhost:6379 uses 
   # ENV['REDIS_URL'] if present.

--- a/lib/nagare/config.rb
+++ b/lib/nagare/config.rb
@@ -5,13 +5,13 @@ module Nagare
   # See the README for possible values and what they do
   class Config
     class << self
-      attr_accessor :dead_consumer_timeout, :group_name, :redis_url, :threads,
-                    :suffix
+      attr_accessor :group_name, :redis_url, :threads, :suffix, :min_idle_time
 
       # Runs code in the block passed in to configure Nagare and sets defaults
       # when values are not set.
       #
-      # returns Nagare::Config self
+      # returns [Nagare::Config] self
+      # rubocop:disable Metrics/CyclomaticComplexity
       def configure
         yield(self)
         @dead_consumer_timeout ||= 5000
@@ -19,8 +19,10 @@ module Nagare
         @redis_url = redis_url || ENV['REDIS_URL'] || 'redis://localhost:6379'
         @threads ||= 1
         @suffix ||= nil
+        @min_idle_time ||= 600_000
         self
       end
+      # rubocop:enable Metrics/CyclomaticComplexity
     end
   end
 end

--- a/lib/nagare/listener.rb
+++ b/lib/nagare/listener.rb
@@ -43,6 +43,7 @@ module Nagare
     # The ClassMethods module is automatically loaded into child classes
     # effectively adding the `stream` class method to the child class.`
     def self.inherited(subclass)
+      super
       subclass.extend(ClassMethods)
     end
 

--- a/lib/nagare/version.rb
+++ b/lib/nagare/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nagare
-  VERSION = '0.1.4'
+  VERSION = '0.1.5'
 end

--- a/nagare.gemspec
+++ b/nagare.gemspec
@@ -20,14 +20,16 @@ Gem::Specification.new do |spec|
   spec.metadata['source_code_uri'] = 'https://github.com/vavato-be/nagare.git'
   spec.metadata['changelog_uri'] = 'https://github.com/vavato-be/nagare/CHANGELOG.md'
 
-  spec.add_dependency 'redis', '~> 4.1', '>= 4.1.0'
+  spec.add_dependency 'redis', '~> 6.2', '>= 6.2.0'
   spec.add_development_dependency 'rubocop', '~> 0.88', '>= 0.88'
   spec.add_development_dependency 'rubocop-rspec', '~> 1.42', '>= 1.42.0'
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+    `git ls-files -z`.split("\x0").reject do |f|
+      f.match(%r{^(test|spec|features)/})
+    end
   end
   spec.bindir = 'exe'
   spec.executables << 'nagare'

--- a/nagare.gemspec
+++ b/nagare.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
   spec.metadata['changelog_uri'] = 'https://github.com/vavato-be/nagare/CHANGELOG.md'
 
   spec.add_dependency 'redis', '~> 6.2', '>= 6.2.0'
-  spec.add_development_dependency 'rubocop', '~> 0.88', '>= 0.88'
-  spec.add_development_dependency 'rubocop-rspec', '~> 1.42', '>= 1.42.0'
+  spec.add_development_dependency 'rubocop', '~> 1.18.3', '>= 1.18.3'
+  spec.add_development_dependency 'rubocop-rspec', '~> 2.4.0', '>= 2.4.0'
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,4 +14,8 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  # Initialize config defaults
+  Nagare::Config.configure do |_config|
+  end
 end


### PR DESCRIPTION
# Description
Currently, nagare does not implement any retry logic. Messages that do not get ACKed by their original consumer remain on the pending list forever.

This PR introduces retries through using the XAUTOCLAIM command introduced in Redis 6.2. The logic is as follows:
- Try to retrieve the next pending message through XAUTOCLAIM that is idle for more than `Nagare::Config.min_idle_time` ms
- If any messages are retrieved this way, don't poll the stream, and processed the claimed message
- If there aren't any pending messages, process the next one on the stream

# Not implemented yet
- *Dead Letter Queue* - Ideally, before or after retrying, nagare would look at the retry count of a certain message and move it to the DLQ instead of retrying after `Nagare::Config.max_retries` has been reached.

# Caveats
After merging this PR, Nagare will REQUIRE Redis 6.2. Any older versions will not work, including Google Cloud's and Amazon's Redis-compatible caching solutions.

The redis-rb gem still needs quite a bit of work before being able to release version 6.2, see https://github.com/redis/redis-rb/issues/978